### PR TITLE
Issue about post a STIX object without objects

### DIFF
--- a/src/api_root/collections/objects/post.py
+++ b/src/api_root/collections/objects/post.py
@@ -28,6 +28,10 @@ def async_post(envelop, collection, taxii2_status, stip_user, community):
             pass
         bundle_objects.append(object_)
         pendings.append((object_id, modified))
+
+    if len(bundle_objects) == 0:
+        return
+
     bundle = Bundle(bundle_objects, allow_custom=True)
 
     try:


### PR DESCRIPTION
Issue about #5 .

We should ignore a STIX 2.1 post request if the `objects` property is empty.
