### PR TITLE
Authenticate by APIKey

### DIFF
--- a/src/auth/basic_auth.py
+++ b/src/auth/basic_auth.py
@@ -1,7 +1,7 @@
 import base64
 import traceback
-import django.contrib.auth
 import core.const as const
+from stip.common.rest_api_auth import auth_by_api_key
 
 
 def _is_exist_http_authorization(headers):
@@ -17,11 +17,8 @@ def get_basic_auth(headers):
             return None
         username_pass = base64.decodebytes(
             base64_username_pass.strip().encode('ascii')).decode('ascii')
-        (username, password) = username_pass.split(':', 1)
-        stip_user = django.contrib.auth.authenticate(
-            username=username,
-            password=password)
-        return stip_user if stip_user else None
+        (username, api_key) = username_pass.split(':', 1)
+        return auth_by_api_key(username, api_key)
     except Exception:
         traceback.print_exc()
         return None


### PR DESCRIPTION
Issue about s-tip/stip-common#89 .
In case of TAXII 1.1 server and TAXII 2.1 server, I fixed to authenticate users by API Key instead of Web Interface credential.
