### PR TITLE
Fixed to return a JSON response on 404 not found.

### DIFF
--- a/src/urls_txs21.py
+++ b/src/urls_txs21.py
@@ -1,7 +1,9 @@
 from django.conf.urls import include, url
 from discovery import views as discovery_views
+from core.response import not_found
 
 urlpatterns = [
     url(r'^taxii2/$', discovery_views.discovery),
     url(r'^(?P<api_root_name>[0-9a-zA-Z_]+?)/', include('api_root.urls')),
+    url(r'^.*$', not_found),
 ]


### PR DESCRIPTION
Issue about #9 .

If a TAXII client request to a S-TIP TAXII 2.1 server without no endpoint, S-TIP TAXII server return 404 HTTP response with HTML contents (it depends on a wsgi application).

A TAXII server must return response that contains a JSON format error information.
